### PR TITLE
Update Roles_lookup_step.php - fix no value return

### DIFF
--- a/classes/steps/lookups/roles_lookup_step.php
+++ b/classes/steps/lookups/roles_lookup_step.php
@@ -49,7 +49,7 @@ class roles_lookup_step extends base_lookup_step {
      *
      * @var array
      */
-    private static $stepfields = array('roles');
+    private static $stepfields = array('roleid');
 
     protected function init() {
         $this->useridfield = $this->data['useridfield'];
@@ -74,11 +74,9 @@ class roles_lookup_step extends base_lookup_step {
         $params = array('userid' => $datafields[$this->useridfield]);
         $userroles = $DB->get_records_sql($sql, $params);
         foreach ($userroles as $role) {
-            foreach ($role as $key => $value) {
-                if (is_scalar($role->roleid)) {
-                    $stepresults[$this->outputprefix . 'roles'][ $role->id][$key] = $value;
-                }
-            }
+			foreach($role as $key => $value){
+				$stepresults[$this->outputprefix . $key] = $value;
+			}
         }
         return [true, $stepresults];
     }


### PR DESCRIPTION
No value was being returned for role lookup.
Changed stepresults assignment to match other lookup files.
Tested in Moodle 3.7.1+ (Build: 20190809)