### PR TITLE
Fixed issue with duplicate emails

### DIFF
--- a/classes/steps/actions/email_action_step.php
+++ b/classes/steps/actions/email_action_step.php
@@ -125,9 +125,13 @@ class email_action_step extends base_action_step {
 
         // Check we have a valid email address.
         if ($emailto == clean_param($emailto, PARAM_EMAIL)) {
-
-            // Check if user exists and use user record.
-            $user = $DB->get_record('user', array('email' => $emailto, 'deleted' => 0));
+            // If user is given from previous step results, use that id
+            if (isset($stepresults['user_id'])) {
+                $user = $DB->get_record('user', array('id' => $stepresults['user_id']));
+            } else {
+                // Check if user exists and use user record.
+                $user = $DB->get_record('user', array('email' => $emailto, 'deleted' => 0));
+            }
 
             // If user not found, use noreply as a base.
             if (empty($user)) {


### PR DESCRIPTION
If there is a case multiple user accounts exist in the installation with the same e-mail address (I know, this isn't recommended, but the use case requires this), this will fail if you only do a lookup based upon email. You should use the id if this is present based upon earlier lookups.