### PR TITLE
really fix queries for mysql

### DIFF
--- a/classes/task/cleanup.php
+++ b/classes/task/cleanup.php
@@ -55,14 +55,14 @@ class cleanup extends \core\task\scheduled_task {
         // Only delete events that do not have an unfinished queue still waiting.
         $sql = "
             DELETE
-              FROM {tool_trigger_events} e
+              FROM {tool_trigger_events}
              WHERE NOT EXISTS (
                        SELECT 1
                          FROM {tool_trigger_queue} q
-                        WHERE q.eventid = e.id
+                        WHERE q.eventid = {tool_trigger_events}.id
                               AND q.status = :statusready
                    )
-                   AND e.timecreated < :timetocleanup";
+                   AND timecreated < :timetocleanup";
         $DB->execute($sql, [
             'statusready' => \tool_trigger\task\process_workflows::STATUS_READY_TO_RUN,
             'timetocleanup' => $timetocleanup
@@ -70,9 +70,9 @@ class cleanup extends \core\task\scheduled_task {
 
         // Now delete processed queue items.
         $sql = "DELETE
-                  FROM {tool_trigger_queue} q
-                 WHERE q.status <> :statusready
-                   AND q.timemodified < :timetocleanup";
+                  FROM {tool_trigger_queue}
+                 WHERE status <> :statusready
+                   AND timemodified < :timetocleanup";
         $DB->execute($sql, [
             'statusready' => \tool_trigger\task\process_workflows::STATUS_READY_TO_RUN,
             'timetocleanup' => $timetocleanup

--- a/classes/task/cleanup_history.php
+++ b/classes/task/cleanup_history.php
@@ -55,15 +55,17 @@ class cleanup_history extends \core\task\scheduled_task {
         // Conditions: Delete steps executed older than duration,
         // But have to check if any steps within duration that rely on that step
         // To be safe for now. Keep all run steps if any in run are over duration.
-        $sql = "DELETE
-                  FROM {tool_trigger_events}
-      WHERE NOT EXISTS (
-                        SELECT 1
-                          FROM {tool_trigger_queue} q
-                         WHERE q.eventid = {tool_trigger_events}.id
-                           AND q.status = :statusready
-                        )
-                   AND timecreated < :timetocleanup";
-        $DB->execute($sql, ['lookback1' => $lookback, 'lookback2' => $lookback]);
+        $sql = "SELECT rh.id FROM {tool_trigger_run_hist} rh
+                      WHERE rh.executed < :lookback1
+                        AND (
+                            SELECT COUNT(id) as count
+                              FROM {tool_trigger_run_hist} sub
+                             WHERE sub.runid = rh.runid
+                               AND sub.executed > :lookback2
+                            ) = 0";
+        $ids = $DB->get_fieldset_sql($sql, ['lookback1' => $lookback, 'lookback2' => $lookback]);
+        if ($ids) {
+            $DB->delete_records_list('tool_trigger_run_hist', 'id', $ids);
+        }
     }
 }

--- a/tests/workflow_manager_test.php
+++ b/tests/workflow_manager_test.php
@@ -145,5 +145,11 @@ class tool_trigger_workflow_manager_testcase extends advanced_testcase {
 
     }
 
+    public function test_cleanup() {
+        $this->resetAfterTest();
+        // Run the task. This only tests that DB query does not throw exceptions.
+        $task = new \tool_trigger\task\cleanup();
+        $task->execute();
+    }
 
 }


### PR DESCRIPTION
the committed fix for #121 - 9f31c2a4ff32144aa3f73a7e26455d3d2e3b4adc has the wrong sql (looks like it came from the other task)  and breaks the \tool_trigger\task\cleanup_history task without addressing the \tool_trigger\task\cleanup query.

This PR fixes both