### PR TITLE
Add missing foreign key for 'stepconfigid' upgrades

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -337,5 +337,20 @@ function xmldb_tool_trigger_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2021030403, 'tool', 'trigger');
     }
 
+    if ($oldversion < 2021030404) {
+
+        // Define key stepconfigid (foreign) to be added to tool_trigger_run_hist.
+        $table = new xmldb_table('tool_trigger_run_hist');
+        $key = new xmldb_key('stepconfigid', XMLDB_KEY_FOREIGN, ['stepconfigid'], 'tool_trigger_steps', ['id']);
+
+        // Launch add key stepconfigid.
+        if (!$table->getKey($key->getName())) {
+            $dbman->add_key($table, $key);
+        }
+
+        // Trigger savepoint reached.
+        upgrade_plugin_savepoint(true, 2021030404, 'tool', 'trigger');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_trigger';
-$plugin->release  = 2021030403;
-$plugin->version  = 2021030403;
+$plugin->release  = 2021030404;
+$plugin->version  = 2021030404;
 $plugin->requires = 2016052300;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = array('tool_monitor' => 2015051101);


### PR DESCRIPTION
Issue when upgrading from a lower version - started from 01950e69828864dad74891b8418a584a11f632ea, since it was not added as part of the upgrade.

Tested locally and it seems regardless of whether the foreign key already exists, the result of the upgrade will be the same.

Closes #140 