### PR TITLE
fix: issue where the user executing the web service was being updated

### DIFF
--- a/classes/steps/actions/webservice_action_step.php
+++ b/classes/steps/actions/webservice_action_step.php
@@ -140,6 +140,11 @@ class webservice_action_step extends base_action_step {
         \core\session\manager::set_user($user);
         set_login_session_preferences();
 
+        // Fake it till you make it - set the the lastaccess in advance to avoid
+        // this value being updated in the database via user_accesstime_log() as
+        // we are not actually logging in and accessing the site as this user.
+        $USER->lastaccess = time();
+
         // Run the function and parse the response to a step result.
         // This entire block is wrapped in a generic handler, so no matter what the correct user is always restored.
         try {

--- a/tests/webservice_action_step_test.php
+++ b/tests/webservice_action_step_test.php
@@ -42,6 +42,8 @@ class tool_trigger_webservice_action_step_testcase extends \advanced_testcase {
      * Simple test, with a successful result.
      */
     public function test_with_valid_call_to_enrol_user() {
+        global $DB;
+
         $adminuser = get_admin();
         $stepsettings = [
             'username' => $adminuser->username,
@@ -49,6 +51,11 @@ class tool_trigger_webservice_action_step_testcase extends \advanced_testcase {
             'params' =>
                 '{"enrolments":{"0":{"roleid":"5","userid":' . $this->user1->id . ',"courseid":' . $this->course->id . '}}}',
         ];
+
+        // Ensure the user provided by the username is not actually 'logged in'
+        // to perform the required actions.
+        $this->assertEquals(0, $adminuser->lastaccess);
+        $this->assertEquals(0, $adminuser->lastlogin);
 
         // Check if user is NOT enrolled yet.
         $context = context_course::instance($this->course->id);
@@ -66,6 +73,10 @@ class tool_trigger_webservice_action_step_testcase extends \advanced_testcase {
         $context = context_course::instance($this->course->id);
         $enrolled = is_enrolled($context, $this->user1->id);
         $this->assertTrue($enrolled);
+
+        $user = $DB->get_record('user', ['id' => $adminuser->id, 'deleted' => 0]);
+        $this->assertEquals(0, $user->lastaccess);
+        $this->assertEquals(0, $user->lastlogin);
     }
 
     /**


### PR DESCRIPTION
This prevents the lastaccess time from being updated, and checks for both lastlogin and lastaccess timestamps to ensure they are unchanged after running the webservice action

Improves upon #182
