### PR TITLE
Improve workflow order

### DIFF
--- a/classes/output/manageworkflows/renderable.php
+++ b/classes/output/manageworkflows/renderable.php
@@ -200,10 +200,15 @@ class renderable extends \table_sql implements \renderable {
         $total = \tool_trigger\workflow_manager::count_workflows();
         $this->pagesize($pagesize, $total);
         $workflows = \tool_trigger\workflow_manager::get_workflows_paginated($this->get_page_start(), $this->get_page_size());
-        // Sort inactive arrays to the bottom.
+
+        // Sort inactive arrays to the bottom and sort by name within each category.
         usort($workflows, function($a, $b) {
-            return ($a->active < $b->active);
+            if ($a->active == $b->active) {
+                return $a->workflow->name <=> $b->workflow->name;
+            }
+            return $b->active <=> $a->active;
         });
+
         $this->rawdata = $workflows;
         // Set initial bars.
         if ($useinitialsbar) {


### PR DESCRIPTION
Improves the display order of workflows by sorting based on active/inactive first, and then by name.

Assume this was the intention all along, as https://github.com/catalyst/moodle-tool_trigger/blob/165cb10beaa390dd6adecbe7d40685e9ad041a21/classes/workflow_manager.php#L131-L147 is sorted by name.