### PR TITLE
Issue#203 Insert tool_trigger_events id into event other data

### DIFF
--- a/classes/helper/datafield_manager.php
+++ b/classes/helper/datafield_manager.php
@@ -99,7 +99,12 @@ trait datafield_manager {
         if (isset($newfields['other']) && is_array($newfields['other'])) {
             foreach ($newfields['other'] as $key => $value) {
                 if (is_scalar($value) || is_null($value)) {
-                    $newfields["other_{$key}"] = $value;
+                    // Retrieve ID from eventid in other data.
+                    if ($key == 'eventid') {
+                        $newfields['id'] = $value;
+                    } else {
+                        $newfields["other_{$key}"] = $value;
+                    }
                 }
             }
             unset($newfields['other']);

--- a/classes/helper/processor_helper.php
+++ b/classes/helper/processor_helper.php
@@ -43,6 +43,12 @@ trait processor_helper {
         if ($data['other'] === false) {
             $data['other'] = array();
         }
+
+        // Insert eventid into other data.
+        if (isset($data['id'])) {
+            $data['other']['eventid'] = $data['id'];
+        }
+
         unset($data['origin']);
         unset($data['ip']);
         unset($data['realuserid']);

--- a/tests/datafield_manager_test.php
+++ b/tests/datafield_manager_test.php
@@ -51,6 +51,12 @@ class tool_trigger_datafield_manager_testcase extends advanced_testcase {
         $dfprovider->update_datafields($this->event, $stepdata);
         $datafields = $dfprovider->get_datafields();
 
+        // Check event id.
+        $this->assertEquals(
+            1,
+            $datafields['id']
+        );
+
         // A field from the event object.
         $this->assertEquals(
             $this->user2->id,

--- a/tests/fixtures/user_event_fixture.php
+++ b/tests/fixtures/user_event_fixture.php
@@ -62,7 +62,8 @@ trait tool_trigger_user_event_fixture {
             'other' => [
                 'courseid' => $this->course->id,
                 'courseshortname' => $this->course->shortname,
-                'coursefullname' => $this->course->fullname
+                'coursefullname' => $this->course->fullname,
+                'eventid' => 1,
             ]
         ]);
 

--- a/tests/processor_helper_test.php
+++ b/tests/processor_helper_test.php
@@ -53,6 +53,7 @@ class tool_trigger_processor_helper_testcase extends tool_trigger_testcase {
      */
     public function test_restore_event() {
         $data = (object) [
+            'id' => 1,
             'eventname' => '\\core\\event\\user_loggedin',
             'component' => 'core',
             'action' => 'loggedin',
@@ -98,6 +99,8 @@ class tool_trigger_processor_helper_testcase extends tool_trigger_testcase {
         $this->assertEquals($expectedevent->userid, $actual->userid);
         $this->assertEquals($expectedevent->objectid, $actual->objectid);
         $this->assertEquals($expectedevent->get_username(), $actual->get_username());
+        // Tool trigger event id
+        $this->assertEquals(1, $actual->other['eventid']);
     }
 
     /**


### PR DESCRIPTION
issue https://github.com/catalyst/moodle-tool_trigger/issues/203

**Testing Instruction**

The purpose of this test is to check if the ID is available only (I am not sure about its usage)

1. Go to Site Admin > Plugins > Admin Tools > Event Trigger > Manage: https://{moodle_site}/admin/tool/trigger/manage.php
2. Add new trigger workflow
3. Enter a name
4. Choose a Event to monitor. Suggested: Core: User Login Failed
5. Enable "Real Time Processing"
6. Click on "Add work flow step"
7. Choose step type: look up
8. Choose step: user lookup
9. Enter name
10. Enter description
11. Enter "id" in "User id data field "
12. Save the step
13. Save the work flow

Before applying the patch

1. Open another browser
2. Try login with non-existing user name/password
3. There will be an error shows that the ID field is invalid (Specified userid field not present in the workflow data: id)

Applying the patch
1. Perform the login again
2. There is no error regards the field ID (we may get non-existing user error as we use event id to find user)

