### PR TITLE
Ensure null not passed to url_encode

### DIFF
--- a/classes/steps/actions/http_post_action_step.php
+++ b/classes/steps/actions/http_post_action_step.php
@@ -127,7 +127,7 @@ class http_post_action_step extends base_action_step {
         // ... urlencode the values of any substitutions being placed into the URL
         // or the POST params.
         $urlencodecallback = function($v) {
-            return urlencode($v);
+            return empty($v) ? $v : urlencode($v);
         };
 
         $url = $this->render_datafields($this->url, null, null, $urlencodecallback);


### PR DESCRIPTION
Before:
```
Moodle 4.1.5+ (Build: 20230908), 1289573dbacfb457127618125c1bd323459d8171
Php: 8.1.2.1.2.13, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.1.0-1019-oem x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

.....................................................R
Deprecated: urlencode(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/defence/admin/tool/trigger/classes/steps/actions/http_post_action_step.php on line 130
.........  63 / 149 ( 42%)
............................................................... 126 / 149 ( 84%)
```

After:
```
Moodle 4.1.5+ (Build: 20230908), 1289573dbacfb457127618125c1bd323459d8171
Php: 8.1.2.1.2.13, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.1.0-1019-oem x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

...............................................................  63 / 149 ( 42%)
............................................................... 126 / 149 ( 84%)
.......................                                         149 / 149 (100%)

Time: 00:14.697, Memory: 402.00 MB

OK (149 tests, 658 assertions)
```
